### PR TITLE
feat: add mcp() and mcp::env() hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@
 
 ## Summary
 
-TODO: Add a short summary of this module.
+p6df module for 1Password: CLI tools (`op`, `1password-cli`), profile switching
+(`OP_ACCOUNT`, `OP_EMAIL`, `OP_VAULT_NAME`), and MCP server support via the op
+plugins directory (`$HOME/.config/op/plugins`) with `OP_SERVICE_ACCOUNT_TOKEN`.
 
 ## Contributing
 
@@ -37,12 +39,14 @@ TODO: Add a short summary of this module.
 
 - `p6df::modules::1password::deps()`
 - `p6df::modules::1password::external::brew()`
+- `p6df::modules::1password::mcp()`
+- `p6df::modules::1password::mcp::env()`
 - `p6df::modules::1password::profile::off()`
 - `p6df::modules::1password::profile::on(profile, account, vault_name)`
   - Args:
-    - profile - 
-    - account - 
-    - vault_name - 
+    - profile
+    - account
+    - vault_name
 - `str str = p6df::modules::1password::prompt::mod()`
 
 ## Hierarchy

--- a/init.zsh
+++ b/init.zsh
@@ -102,3 +102,35 @@ p6df::modules::1password::profile::off() {
 
   p6_return_void
 }
+
+######################################################################
+#<
+#
+# Function: p6df::modules::1password::mcp()
+#
+#  Environment:	 HOME
+#>
+######################################################################
+p6df::modules::1password::mcp() {
+
+  p6df::core::path::if "$HOME/.config/op/plugins"
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: p6df::modules::1password::mcp::env()
+#
+#  Environment:	 OP_SERVICE_ACCOUNT_TOKEN
+#>
+######################################################################
+p6df::modules::1password::mcp::env() {
+
+  if p6_string_blank "$OP_SERVICE_ACCOUNT_TOKEN"; then
+    p6_env_export_un "OP_SERVICE_ACCOUNT_TOKEN"
+  fi
+
+  p6_return_void
+}


### PR DESCRIPTION
## Summary

- Add `mcp()` hook: exposes `$HOME/.config/op/plugins` via `p6df::core::path::if` so op plugins are in PATH for MCP servers
- Add `mcp::env()` hook: clears `OP_SERVICE_ACCOUNT_TOKEN` when not set

## Test plan

- [ ] `p6df mcp` installs/configures op plugins path
- [ ] `p6df mcp::env` clears token env var when blank

🤖 Generated with [Claude Code](https://claude.com/claude-code)