### PR TITLE
fix: add @takescake/1password-mcp npm package install

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
 ## Summary
 
 p6df module for 1Password: CLI tools (`op`, `1password-cli`), profile switching
-(`OP_ACCOUNT`, `OP_EMAIL`, `OP_VAULT_NAME`), and MCP server support via the op
-plugins directory (`$HOME/.config/op/plugins`) with `OP_SERVICE_ACCOUNT_TOKEN`.
+(`OP_ACCOUNT`, `OP_EMAIL`, `OP_VAULT_NAME`), and MCP server support via op
+plugins directory and `@takescake/1password-mcp` with `OP_SERVICE_ACCOUNT_TOKEN`.
 
 ## Contributing
 

--- a/init.zsh
+++ b/init.zsh
@@ -114,6 +114,7 @@ p6df::modules::1password::profile::off() {
 p6df::modules::1password::mcp() {
 
   p6df::core::path::if "$HOME/.config/op/plugins"
+  p6_js_npm_global_install "@takescake/1password-mcp"
 
   p6_return_void
 }


### PR DESCRIPTION
## Summary

- Fix `mcp()` hook: add `@takescake/1password-mcp` npm install alongside the existing op plugins PATH setup, matching the configured MCP server package

## Test plan

- [ ] `p6df mcp` installs `@takescake/1password-mcp` and adds op plugins to PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)