### PR TITLE
feat: fold mcp::env into profile::on/off, fetch OP_SERVICE_ACCOUNT_TOKEN from 1pw

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Build
 
 on:
   pull_request: {}
+  push: {}
+  merge_group: {}
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,6 +2,7 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, ready_for_review, synchronize]
+  merge_group: {}
 
 permissions:
   contents: read
@@ -11,8 +12,13 @@ permissions:
 jobs:
   claude-review:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
     steps:
-      - uses: p6m7g8-actions/claude@main
+      - name: Skip on merge queue
+        if: github.event_name == 'merge_group'
+        run: echo "Skipping review in merge queue context"
+      - name: Run claude review
+        if: github.event_name != 'merge_group' && github.event.pull_request.draft == false
+        continue-on-error: true
+        uses: p6m7g8-actions/claude@main
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -2,6 +2,7 @@ name: Codex Code Review
 on:
   pull_request:
     types: [opened, ready_for_review, synchronize]
+  merge_group: {}
 
 permissions:
   contents: read
@@ -11,8 +12,12 @@ permissions:
 jobs:
   codex-review:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
     steps:
-      - uses: p6m7g8-actions/codex@main
+      - name: Skip on merge queue
+        if: github.event_name == 'merge_group'
+        run: echo "Skipping review in merge queue context"
+      - name: Run codex review
+        if: github.event_name != 'merge_group' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false
+        uses: p6m7g8-actions/codex@main
         with:
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -9,6 +9,7 @@ on:
       - reopened
       - ready_for_review
       - edited
+  merge_group: {}
 
 jobs:
   lint:
@@ -17,7 +18,11 @@ jobs:
     permissions:
       pull-requests: read
     steps:
+      - name: Skip on merge queue
+        if: github.event_name == 'merge_group'
+        run: echo "Skipping lint in merge queue context"
       - name: Lint PR title
+        if: github.event_name != 'merge_group'
         uses: p6m7g8-actions/p6-gh-pr-title-linter@main
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@
 
 ## Summary
 
-p6df module for 1Password: CLI tools (`op`, `1password-cli`), profile switching
-(`OP_ACCOUNT`, `OP_EMAIL`, `OP_VAULT_NAME`), and MCP server support via op
-plugins directory and `@takescake/1password-mcp` with `OP_SERVICE_ACCOUNT_TOKEN`.
+Integrates 1Password CLI into the p6df shell framework. Provides profile-based account/vault
+switching, MCP server installation, and credential export (including `OP_SERVICE_ACCOUNT_TOKEN`)
+via `profile::on` / `profile::off`.
 
 ## Contributing
 
@@ -40,13 +40,13 @@ plugins directory and `@takescake/1password-mcp` with `OP_SERVICE_ACCOUNT_TOKEN`
 - `p6df::modules::1password::deps()`
 - `p6df::modules::1password::external::brew()`
 - `p6df::modules::1password::mcp()`
-- `p6df::modules::1password::mcp::env()`
 - `p6df::modules::1password::profile::off()`
-- `p6df::modules::1password::profile::on(profile, account, vault_name)`
+- `p6df::modules::1password::profile::on(profile, account, vault_name, [op_service_account_token=])`
   - Args:
     - profile
     - account
     - vault_name
+    - OPTIONAL op_service_account_token - []
 - `str str = p6df::modules::1password::prompt::mod()`
 
 ## Hierarchy

--- a/init.zsh
+++ b/init.zsh
@@ -62,25 +62,32 @@ p6df::modules::1password::prompt::mod() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::1password::profile::on(profile, account, vault_name)
+# Function: p6df::modules::1password::profile::on(profile, account, vault_name, [op_service_account_token=])
 #
 #  Args:
 #	profile -
 #	account -
 #	vault_name -
+#	OPTIONAL op_service_account_token - []
 #
-#  Environment:	 P6_DFZ_PROFILE_1PASSWORD
+#  Environment:	 OP_SERVICE_ACCOUNT_TOKEN P6_DFZ_PROFILE_1PASSWORD
 #>
 ######################################################################
 p6df::modules::1password::profile::on() {
   local profile="$1"
   local account="$2"
   local vault_name="$3"
+  local op_service_account_token="${4:-}"
 
   p6_env_export "P6_DFZ_PROFILE_1PASSWORD" "$profile"
   p6_1password_account_signin "$account"
   p6_1password_whoami_email
   p6_1password_vault_select "$vault_name"
+
+  p6_env_export_un OP_SERVICE_ACCOUNT_TOKEN
+  if p6_string_blank_NOT "$op_service_account_token"; then
+    p6_env_export "OP_SERVICE_ACCOUNT_TOKEN" "$op_service_account_token"
+  fi
 
   p6_return_void
 }
@@ -90,7 +97,7 @@ p6df::modules::1password::profile::on() {
 #
 # Function: p6df::modules::1password::profile::off()
 #
-#  Environment:	 OP_ACCOUNT OP_EMAIL OP_VAULT_NAME P6_DFZ_PROFILE_1PASSWORD
+#  Environment:	 OP_ACCOUNT OP_EMAIL OP_SERVICE_ACCOUNT_TOKEN OP_VAULT_NAME P6_DFZ_PROFILE_1PASSWORD
 #>
 ######################################################################
 p6df::modules::1password::profile::off() {
@@ -98,6 +105,7 @@ p6df::modules::1password::profile::off() {
   p6_env_export_un P6_DFZ_PROFILE_1PASSWORD
   p6_env_export_un OP_ACCOUNT
   p6_env_export_un OP_EMAIL
+  p6_env_export_un OP_SERVICE_ACCOUNT_TOKEN
   p6_env_export_un OP_VAULT_NAME
 
   p6_return_void
@@ -115,23 +123,6 @@ p6df::modules::1password::mcp() {
 
   p6df::core::path::if "$HOME/.config/op/plugins"
   p6_js_npm_global_install "@takescake/1password-mcp"
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::1password::mcp::env()
-#
-#  Environment:	 OP_SERVICE_ACCOUNT_TOKEN
-#>
-######################################################################
-p6df::modules::1password::mcp::env() {
-
-  if p6_string_blank "$OP_SERVICE_ACCOUNT_TOKEN"; then
-    p6_env_export_un "OP_SERVICE_ACCOUNT_TOKEN"
-  fi
 
   p6_return_void
 }


### PR DESCRIPTION
## Summary

- Add optional `op_service_account_token` param to `profile::on()`; exports `OP_SERVICE_ACCOUNT_TOKEN` when provided
- `profile::off()` now unsets `OP_SERVICE_ACCOUNT_TOKEN` alongside other `OP_*` vars
- Remove `mcp::env()` hook — MCP auth env is now managed entirely by the profile system
- Callers (`select::me()`) fetch the token from 1Password and pass it through

## Test plan
- [ ] `p6_p_home` sets `OP_SERVICE_ACCOUNT_TOKEN` when the 1pw item exists
- [ ] `profile::off()` clears `OP_SERVICE_ACCOUNT_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)