### PR TITLE
fix(profile): replace placeholder vars with actual env var names OP_ACCOUNT OP_EMAIL OP_VAULT_NAME

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -64,7 +64,7 @@ p6df::modules::1password::profile::on() {
 ######################################################################
 p6df::modules::1password::profile::mod() {
 
-  p6_return_words '1password' "$" "$" "$"
+  p6_return_words '1password' '$OP_ACCOUNT' '$OP_EMAIL' '$OP_VAULT_NAME'
 }
 
 ######################################################################


### PR DESCRIPTION
## What
Replace placeholder `$` strings in `p6df::modules::1password::profile::mod` with the actual environment variable names: `$OP_ACCOUNT`, `$OP_EMAIL`, and `$OP_VAULT_NAME`.

## Why
The previous code passed literal `"$"` strings instead of the intended 1Password environment variable references, making the profile mod function return useless placeholder values instead of actual account information.

## Test plan
- Reviewed diff manually
- Function now returns the correct env var names for 1Password configuration

## Dependencies
None