### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,23 +1,11 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::1password::deps()
-#
-#>
-######################################################################
 p6df::modules::1password::deps() {
   ModuleDeps=(
 	  p6m7g8-dotfiles/p61password
   )
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::1password::external::brews()
-#
-#>
 ######################################################################
 p6df::modules::1password::external::brews() {
 
@@ -28,16 +16,16 @@ p6df::modules::1password::external::brews() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::1password::profile::on(profile, account, vault_name)
-#
-#  Args:
-#	profile -
-#	account -
-#	vault_name -
-#
-#>
+p6df::modules::1password::mcp() {
+
+  p6df::core::path::if "$HOME/.config/op/plugins"
+  p6_js_npm_global_install "@takescake/1password-mcp"
+
+  p6df::modules::anthropic::mcp::server::add "1password" "npx" "-y" "@takescake/1password-mcp"
+  p6df::modules::openai::mcp::server::add "1password" "npx" "-y" "@takescake/1password-mcp"
+
+  p6_return_void
+}
 ######################################################################
 p6df::modules::1password::profile::on() {
   local profile="$1"
@@ -52,6 +40,35 @@ p6df::modules::1password::profile::on() {
 }
 
 ######################################################################
+p6df::modules::1password::profile::mod() {
+
+  p6_return_words '1password' '$OP_ACCOUNT' '$OP_EMAIL' '$OP_VAULT_NAME'
+}
+
+######################################################################
+#<
+#
+# Function: p6df::modules::1password::deps()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::1password::external::brews()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::1password::profile::on(profile, account, vault_name)
+#
+#  Args:
+#	profile -
+#	account -
+#	vault_name -
+#
+#>
+######################################################################
 #<
 #
 # Function: words 1password = p6df::modules::1password::profile::mod()
@@ -62,26 +79,9 @@ p6df::modules::1password::profile::on() {
 #  Environment:	 OP_ACCOUNT OP_EMAIL OP_VAULT_NAME
 #>
 ######################################################################
-p6df::modules::1password::profile::mod() {
-
-  p6_return_words '1password' '$OP_ACCOUNT' '$OP_EMAIL' '$OP_VAULT_NAME'
-}
-
-######################################################################
 #<
 #
 # Function: p6df::modules::1password::mcp()
 #
 #  Environment:	 HOME
 #>
-######################################################################
-p6df::modules::1password::mcp() {
-
-  p6df::core::path::if "$HOME/.config/op/plugins"
-  p6_js_npm_global_install "@takescake/1password-mcp"
-
-  p6df::modules::anthropic::mcp::server::add "1password" "npx" "-y" "@takescake/1password-mcp"
-  p6df::modules::openai::mcp::server::add "1password" "npx" "-y" "@takescake/1password-mcp"
-
-  p6_return_void
-}

--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,23 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::1password::deps()
+#
+#>
+######################################################################
 p6df::modules::1password::deps() {
   ModuleDeps=(
 	  p6m7g8-dotfiles/p61password
   )
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::1password::external::brews()
+#
+#>
 ######################################################################
 p6df::modules::1password::external::brews() {
 
@@ -15,6 +27,13 @@ p6df::modules::1password::external::brews() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::1password::mcp()
+#
+#  Environment:	 HOME
+#>
 ######################################################################
 p6df::modules::1password::mcp() {
 
@@ -26,6 +45,17 @@ p6df::modules::1password::mcp() {
 
   p6_return_void
 }
+######################################################################
+#<
+#
+# Function: p6df::modules::1password::profile::on(profile, account, vault_name)
+#
+#  Args:
+#	profile -
+#	account -
+#	vault_name -
+#
+#>
 ######################################################################
 p6df::modules::1password::profile::on() {
   local profile="$1"
@@ -40,35 +70,6 @@ p6df::modules::1password::profile::on() {
 }
 
 ######################################################################
-p6df::modules::1password::profile::mod() {
-
-  p6_return_words '1password' '$OP_ACCOUNT' '$OP_EMAIL' '$OP_VAULT_NAME'
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::1password::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::1password::external::brews()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::1password::profile::on(profile, account, vault_name)
-#
-#  Args:
-#	profile -
-#	account -
-#	vault_name -
-#
-#>
-######################################################################
 #<
 #
 # Function: words 1password = p6df::modules::1password::profile::mod()
@@ -79,9 +80,8 @@ p6df::modules::1password::profile::mod() {
 #  Environment:	 OP_ACCOUNT OP_EMAIL OP_VAULT_NAME
 #>
 ######################################################################
-#<
-#
-# Function: p6df::modules::1password::mcp()
-#
-#  Environment:	 HOME
-#>
+p6df::modules::1password::profile::mod() {
+
+  p6_return_words '1password' '$OP_ACCOUNT' '$OP_EMAIL' '$OP_VAULT_NAME'
+}
+


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None